### PR TITLE
Build with Visual Studio 2015 on Windows

### DIFF
--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -1,10 +1,7 @@
-if "%ARCH%" == "32" (set PLATFORM=x86) else (set PLATFORM=x64)
-call "%VS120COMNTOOLS%\..\..\VC\vcvarsall.bat" %PLATFORM%
-
 mkdir build
 cd build
 
-cmake -G "NMake Makefiles" ^
+cmake -G "%CMAKE_GENERATOR%" ^
     -DCMAKE_BUILD_TYPE="Release" ^
     -DCMAKE_PREFIX_PATH=%LIBRARY_PREFIX% ^
     -DCMAKE_INSTALL_PREFIX:PATH=%LIBRARY_PREFIX% ^
@@ -17,8 +14,8 @@ cmake -G "NMake Makefiles" ^
 
 if errorlevel 1 exit 1
 
-nmake
+cmake --build . --config "%BUILD_CONFIG%"
 if errorlevel 1 exit 1
 
-nmake install
+cmake --build . --config "%BUILD_CONFIG%" --target install
 if errorlevel 1 exit 1

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -3,7 +3,7 @@
 {% set sha256 = "1fd90354b9cf19232e8f168faf2220e79be555df3aa743242700879e8fd329ee" %}
 
 {% set llvm_variant = os.environ.get('LLVM_VARIANT', 'default') %}
-{% set build_number = "2" %}
+{% set build_number = "3" %}
 {% set build_string = "{}_{}".format(llvm_variant, build_number) %}
 
 package:
@@ -57,6 +57,7 @@ requirements:
     - system  # [linux and not armv7l]
   run:
     - system  # [linux and not armv7l]
+    - vs2015_runtime  # [win and py36]
 
 test:
   requires:                                                  # [win]


### PR DESCRIPTION
While trying to build Mesa's llvmpipe on Windows, I've got lots of link errors like ```LLVMCodeGen.lib(LowerEmuTLS.obj) : error LNK2038: mismatch detected for '_MSC_VER': value '1800' doesn't match value '1900'``` and then realized that even though ```llvmdev``` declares ```vc14``` it is actually compiled with VS2013.

I believe this was done by mistake, but in case a VS2013 build is still really necessary, we should not generate a package with ```vc14``` and probably depend on ```vs2013_runtime```