### PR TITLE
Set LLVM to build default (all) targets

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -55,6 +55,6 @@ install:
       source run_conda_forge_build_setup
 
 script:
-  - conda build ./recipe
+  - travis_wait conda build ./recipe
 
   - upload_or_check_non_existence ./recipe conda-forge --channel=main

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,7 @@ env:
   global:
     # The BINSTAR_TOKEN secure variable. This is defined canonically in conda-forge.yml.
     - secure: "Rsc1XQLxRBgjpg44G1LYdAHpnYMs3K4KA0k5vU+bd6xEwaPx+Qj3AZFaf2wXyaB/pLn1BGkYCUbnoEoCiGTMhGaiiuf1G/eSUbI4jLUryDhJL08kLl83dPjOJE5gZ/nw/ZPbgEkAKWLM/+Y6ZRIqDsxZKSPxfw72OohsIKcWk5ASpdFfUecuFQw/Da2By5DSgWKsUyZhA848nx3vEn0pNktmRjH4L/cFWmphlDKnXifMaKi4HjSHA1yY3/JLVYkKOeNxEBNUYvcrUvtLXqdjfXZQnhMer16xgigqY3LRxFb91UCTBAD9oRIvZgG5N+cqAuTPwyUDRb6wTX6LcEcIOtD7XyVtiZpNTiE/LhH1yqJPBqgUNqUcWV9PDpmsFmeUsbnLYRS/4ohdJeA/LGghWIRzg2s99bZWsi4+NeTQSlrPfZFNW8fuNOLfCFmG+MVc9nQWNFeBhix1KVzy5SAqyxcr/k7QwnZQ9ov+hzNvwW74gkTQCWsG8gHvdCOSHW7mozcCVjcD5tWZ8OQuZVQPC9KZUC08iEV0pLOKgeRX+fMWCvaLq9Q93S+xifQpMzBPUcPIU/8WuuRxJfGwnDnaCGkBJvqdDCCo4dG8aZnT9lBo4+XC2wWzjqZuk3Ckc+/PlCiq6A4ZogrAmPyRV3m8UtgOJ/dXmlK0SdxQxgT9bV8="
+    - MAKEFLAGS="-j 2"
 
 
 before_install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,8 @@ language: generic
 os: osx
 osx_image: xcode6.4
 
+cache: ccache
+
 env:
   matrix:
     

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,6 @@ env:
   global:
     # The BINSTAR_TOKEN secure variable. This is defined canonically in conda-forge.yml.
     - secure: "Rsc1XQLxRBgjpg44G1LYdAHpnYMs3K4KA0k5vU+bd6xEwaPx+Qj3AZFaf2wXyaB/pLn1BGkYCUbnoEoCiGTMhGaiiuf1G/eSUbI4jLUryDhJL08kLl83dPjOJE5gZ/nw/ZPbgEkAKWLM/+Y6ZRIqDsxZKSPxfw72OohsIKcWk5ASpdFfUecuFQw/Da2By5DSgWKsUyZhA848nx3vEn0pNktmRjH4L/cFWmphlDKnXifMaKi4HjSHA1yY3/JLVYkKOeNxEBNUYvcrUvtLXqdjfXZQnhMer16xgigqY3LRxFb91UCTBAD9oRIvZgG5N+cqAuTPwyUDRb6wTX6LcEcIOtD7XyVtiZpNTiE/LhH1yqJPBqgUNqUcWV9PDpmsFmeUsbnLYRS/4ohdJeA/LGghWIRzg2s99bZWsi4+NeTQSlrPfZFNW8fuNOLfCFmG+MVc9nQWNFeBhix1KVzy5SAqyxcr/k7QwnZQ9ov+hzNvwW74gkTQCWsG8gHvdCOSHW7mozcCVjcD5tWZ8OQuZVQPC9KZUC08iEV0pLOKgeRX+fMWCvaLq9Q93S+xifQpMzBPUcPIU/8WuuRxJfGwnDnaCGkBJvqdDCCo4dG8aZnT9lBo4+XC2wWzjqZuk3Ckc+/PlCiq6A4ZogrAmPyRV3m8UtgOJ/dXmlK0SdxQxgT9bV8="
-    - MAKEFLAGS="-j 2"
 
 
 before_install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,9 @@ env:
   global:
     # The BINSTAR_TOKEN secure variable. This is defined canonically in conda-forge.yml.
     - secure: "Rsc1XQLxRBgjpg44G1LYdAHpnYMs3K4KA0k5vU+bd6xEwaPx+Qj3AZFaf2wXyaB/pLn1BGkYCUbnoEoCiGTMhGaiiuf1G/eSUbI4jLUryDhJL08kLl83dPjOJE5gZ/nw/ZPbgEkAKWLM/+Y6ZRIqDsxZKSPxfw72OohsIKcWk5ASpdFfUecuFQw/Da2By5DSgWKsUyZhA848nx3vEn0pNktmRjH4L/cFWmphlDKnXifMaKi4HjSHA1yY3/JLVYkKOeNxEBNUYvcrUvtLXqdjfXZQnhMer16xgigqY3LRxFb91UCTBAD9oRIvZgG5N+cqAuTPwyUDRb6wTX6LcEcIOtD7XyVtiZpNTiE/LhH1yqJPBqgUNqUcWV9PDpmsFmeUsbnLYRS/4ohdJeA/LGghWIRzg2s99bZWsi4+NeTQSlrPfZFNW8fuNOLfCFmG+MVc9nQWNFeBhix1KVzy5SAqyxcr/k7QwnZQ9ov+hzNvwW74gkTQCWsG8gHvdCOSHW7mozcCVjcD5tWZ8OQuZVQPC9KZUC08iEV0pLOKgeRX+fMWCvaLq9Q93S+xifQpMzBPUcPIU/8WuuRxJfGwnDnaCGkBJvqdDCCo4dG8aZnT9lBo4+XC2wWzjqZuk3Ckc+/PlCiq6A4ZogrAmPyRV3m8UtgOJ/dXmlK0SdxQxgT9bV8="
+    # It's possible that Travis already set CC/CXX in which case we're clobbering them.
+    - CC="ccache cc"
+    - CXX="ccache c++"
 
 
 before_install:

--- a/ci_support/run_docker_build.sh
+++ b/ci_support/run_docker_build.sh
@@ -41,6 +41,9 @@ conda clean --lock
 conda install --yes --quiet conda-forge-build-setup
 source run_conda_forge_build_setup
 
+# Install ccache
+conda install --yes --quiet ccache
+
 # Embarking on 2 case(s).
     set -x
     export LLVM_VARIANT=cling

--- a/ci_support/run_docker_build.sh
+++ b/ci_support/run_docker_build.sh
@@ -48,6 +48,8 @@ conda install --yes --quiet ccache
     set -x
     export LLVM_VARIANT=cling
     export CONDA_PY=36
+    export CC="ccache cc"
+    export CXX="ccache c++"
     set +x
     conda build /recipe_root --quiet || exit 1
     upload_or_check_non_existence /recipe_root conda-forge --channel=main || exit 1

--- a/circle.yml
+++ b/circle.yml
@@ -6,6 +6,10 @@ checkout:
 machine:
   services:
     - docker
+  environment:
+    # It's possible that CircleCI set CC/CXX, in which case we're clobbering them.
+    CC: ccache cc
+    CXX: ccache c++
 
 dependencies:
   # Note, we used to use the naive caching of docker images, but found that it was quicker

--- a/circle.yml
+++ b/circle.yml
@@ -2,6 +2,7 @@ checkout:
   post:
     - ./ci_support/checkout_merge_commit.sh
 
+
 machine:
   services:
     - docker
@@ -11,6 +12,8 @@ dependencies:
   # just to pull each time. #rollondockercaching
   override:
     - docker pull condaforge/linux-anvil
+  cache_directories:
+    - "~/.ccache"
 
 test:
   override:

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -20,6 +20,6 @@ cmake -DCMAKE_INSTALL_PREFIX="${PREFIX}" \
       -DLLVM_ENABLE_TERMINFO=OFF \
       ..
 
-echo "Building -j${CPU_COUNT}"
+echo "Building -j3" # TODO: test hack
 make -j${CPU_COUNT}
 make install

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -3,7 +3,6 @@ cd build
 
 cmake -DCMAKE_INSTALL_PREFIX="${PREFIX}" \
       -DCMAKE_BUILD_TYPE=Release \
-      -DLLVM_TARGETS_TO_BUILD=host \
       -DLLVM_ENABLE_RTTI=ON \
       -DLLVM_INCLUDE_TESTS=OFF \
       -DLLVM_INCLUDE_UTILS=OFF \

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -1,6 +1,13 @@
 mkdir build
 cd build
 
+if [ -x "$(command -v ccache)" ]; then
+  ENABLE_CCACHE=ON
+else
+  ENABLE_CCACHE=OFF
+  echo "WARNING: Failed to find ccache"
+fi
+
 cmake -DCMAKE_INSTALL_PREFIX="${PREFIX}" \
       -DCMAKE_BUILD_TYPE=Release \
       -DLLVM_ENABLE_RTTI=ON \
@@ -9,6 +16,7 @@ cmake -DCMAKE_INSTALL_PREFIX="${PREFIX}" \
       -DLLVM_INCLUDE_DOCS=OFF \
       -DLLVM_INCLUDE_EXAMPLES=OFF \
       -DLLVM_ENABLE_TERMINFO=OFF \
+      -DLLVM_CCACHE_BUILD=$ENABLE_CCACHE \
       ..
 
 echo "Building -j${CPU_COUNT}"

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -1,12 +1,14 @@
 mkdir build
 cd build
 
-if [ -x "$(command -v ccache)" ]; then
-  ENABLE_CCACHE=ON
-else
-  ENABLE_CCACHE=OFF
-  echo "WARNING: Failed to find ccache"
-fi
+# Not supported until trunk/4.xx: -DLLVM_CCACHE_BUILD=$ENABLE_CCACHE \
+# Instead work with explicit CC=ccache cc
+#if [ -x "$(command -v ccache)" ]; then
+#  ENABLE_CCACHE=ON
+#else
+#  ENABLE_CCACHE=OFF
+#  echo "WARNING: Failed to find ccache"
+#fi
 
 cmake -DCMAKE_INSTALL_PREFIX="${PREFIX}" \
       -DCMAKE_BUILD_TYPE=Release \
@@ -16,7 +18,6 @@ cmake -DCMAKE_INSTALL_PREFIX="${PREFIX}" \
       -DLLVM_INCLUDE_DOCS=OFF \
       -DLLVM_INCLUDE_EXAMPLES=OFF \
       -DLLVM_ENABLE_TERMINFO=OFF \
-      -DLLVM_CCACHE_BUILD=$ENABLE_CCACHE \
       ..
 
 echo "Building -j${CPU_COUNT}"

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -11,5 +11,6 @@ cmake -DCMAKE_INSTALL_PREFIX="${PREFIX}" \
       -DLLVM_ENABLE_TERMINFO=OFF \
       ..
 
+echo "Building -j${CPU_COUNT}"
 make -j${CPU_COUNT}
 make install

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -22,5 +22,10 @@ cmake -DCMAKE_INSTALL_PREFIX="${PREFIX}" \
 
 export CPU_COUNT=3
 echo "Building -j${CPU_COUNT}" # TODO: test hack
+date
 make -j${CPU_COUNT}
+date
+echo "Build done"
 make install
+date
+echo "Install done"

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -20,6 +20,7 @@ cmake -DCMAKE_INSTALL_PREFIX="${PREFIX}" \
       -DLLVM_ENABLE_TERMINFO=OFF \
       ..
 
-echo "Building -j3" # TODO: test hack
+export CPU_COUNT=3
+echo "Building -j${CPU_COUNT}" # TODO: test hack
 make -j${CPU_COUNT}
 make install

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -3,7 +3,7 @@
 {% set sha256 = "1fd90354b9cf19232e8f168faf2220e79be555df3aa743242700879e8fd329ee" %}
 
 {% set llvm_variant = os.environ.get('LLVM_VARIANT', 'default') %}
-{% set build_number = "4" %}
+{% set build_number = "5" %}
 
 package:
   name: llvmdev


### PR DESCRIPTION
Non-Windows: all targets.
Windows: still host-only, in my understanding.

When actually using LLVM (as opposed to just installing a Clang/LLVM toolchain), it's often important to have non-host targets available (especially ARM*, PTX, etc.). This revises the current build to include all targets.