### PR TITLE
Use m2w64-xz always

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -48,8 +48,7 @@ requirements:
     - toolchain
     - cmake
     # Needed to unpack the source tarball
-    - m2-xz  # [py27 and win32]
-    - m2w64-xz  # [py27 and win64]
+    - m2w64-xz  # [py27 and win]
     - ninja  # [win]
     # Needed to build LLVM
     - python


### PR DESCRIPTION
That m2-xz was used for win32 and m2w64-xz was used for win64 shows
a misunderstanding about what these package prefixes mean.

m2-xz is a Cygwin-a-like package (implements FHS, can fork is always GPL)
m2w64-xz is a native Windows package (cannot fork, license as per upstream)

m2w64 does *not* mean 64-bit. It means a package compiled using mingw-w64
which is the 64-bit *capable* fork of mingw.org