### PR TITLE
Drop unused `shortversion`  [ci skip]

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,3 @@
-{% set shortversion = "5.0" %}
 {% set version = "6.0.0" %}
 {% set sha256 = "1ff53c915b4e761ef400b803f07261ade637b0c269d99569f18040f3dcee4408" %}
 


### PR DESCRIPTION
As `shortversion` is no longer used in the recipe, just drop it from the Jinja definitions.

xref: https://github.com/conda-forge/llvmdev-feedstock/pull/32#pullrequestreview-112288304

cc @inducer