### PR TITLE
Add CFGPrinter undefined behavior patch

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -15,6 +15,7 @@ source:
   patches:
     - llvm-lto-static.patch   # [win]
     - export_LLVMInitializeInstCombine.diff
+    - twine_cfg_undefined_behavior.patch
 {% if llvm_variant == "cling" %}
     - cling-patches/0001-Add-interface-to-create-DyLib-from-dlopen-handle.patch
     - cling-patches/0002-Add-cling-as-tool-to-be-built.patch

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -2,7 +2,7 @@
 {% set sha256 = "1ff53c915b4e761ef400b803f07261ade637b0c269d99569f18040f3dcee4408" %}
 
 {% set llvm_variant = os.environ.get('LLVM_VARIANT', 'default') %}
-{% set build_number = "1" %}
+{% set build_number = "2" %}
 
 package:
   name: llvmdev

--- a/recipe/twine_cfg_undefined_behavior.patch
+++ b/recipe/twine_cfg_undefined_behavior.patch
@@ -1,0 +1,26 @@
+From b42222e01abc1a799c4e421fa26d72d49afe4b99 Mon Sep 17 00:00:00 2001
+From: Siu Kwan Lam <michael.lam.sk@gmail.com>
+Date: Fri, 23 Mar 2018 11:46:45 -0500
+Subject: [PATCH] Patch to fix undefined behavior in cfgprinter
+
+---
+ include/llvm/Analysis/CFGPrinter.h | 3 +--
+ 1 file changed, 1 insertion(+), 2 deletions(-)
+
+diff --git a/include/llvm/Analysis/CFGPrinter.h b/include/llvm/Analysis/CFGPrinter.h
+index 5786769..a4b642b 100644
+--- a/include/llvm/Analysis/CFGPrinter.h
++++ b/include/llvm/Analysis/CFGPrinter.h
+@@ -172,8 +172,7 @@ struct DOTGraphTraits<const Function*> : public DefaultDOTGraphTraits {
+ 
+     // Prepend a 'W' to indicate that this is a weight rather than the actual
+     // profile count (due to scaling).
+-    Twine Attrs = "label=\"W:" + Twine(Weight->getZExtValue()) + "\"";
+-    return Attrs.str();
++    return ("label=\"W:" + Twine(Weight->getZExtValue()) + "\"").str();
+   }
+ };
+ } // End llvm namespace
+-- 
+2.10.1
+


### PR DESCRIPTION
Adds a patch to workaround [an upstream bug]( https://bugs.llvm.org/show_bug.cgi?id=37019 ). This is needed for Numba 0.38.0. ( https://github.com/conda-forge/numba-feedstock/pull/7 )

Thanks @stuartarchibald for [the advice]( https://github.com/numba/numba/issues/2437#issuecomment-385429154 ).