### PR TITLE
Fix 9.x osx-arm64

### DIFF
--- a/.ci_support/osx_64_.yaml
+++ b/.ci_support/osx_64_.yaml
@@ -5,7 +5,7 @@ channel_sources:
 channel_targets:
 - conda-forge main
 cxx_compiler:
-- clangxx
+- clang_bootstrap
 cxx_compiler_version:
 - '11'
 macos_machine:

--- a/.ci_support/osx_arm64_.yaml
+++ b/.ci_support/osx_arm64_.yaml
@@ -5,7 +5,7 @@ channel_sources:
 channel_targets:
 - conda-forge main
 cxx_compiler:
-- clangxx
+- clang_bootstrap
 cxx_compiler_version:
 - '11'
 macos_machine:

--- a/.ci_support/win_64_.yaml
+++ b/.ci_support/win_64_.yaml
@@ -2,6 +2,8 @@ channel_sources:
 - conda-forge,defaults
 channel_targets:
 - conda-forge main
+cxx_compiler:
+- vs2017
 pin_run_as_build:
   zlib:
     max_pin: x.x

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -1,0 +1,4 @@
+c_compiler:         # [osx]
+  - clang_bootstrap # [osx]
+cxx_compiler:       # [osx]
+  - clang_bootstrap # [osx]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -18,7 +18,7 @@ source:
     - patches/amd-roc-2.7.0.diff
 
 build:
-  number: 2
+  number: 3
   skip:  true  # [(win and vc<14) or ppc64le]
   merge_build_host: False
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -24,9 +24,7 @@ build:
 
 requirements:
   build:
-    - {{ compiler('cxx') }}            # [linux]
-    - vs2017_{{ target_platform }}     # [win]
-    - clang_bootstrap_osx-64           # [osx]
+    - {{ compiler('cxx') }}
     - cmake
     - ninja     # [win]
     - python    >=3
@@ -46,9 +44,7 @@ outputs:
       activate_in_script: True
     requirements:
       build:
-        - {{ compiler('cxx') }}            # [linux]
-        - vs2017_{{ target_platform }}     # [win]
-        - clang_bootstrap_osx-64           # [osx]
+        - {{ compiler('cxx') }}
         - cmake
         - ninja     # [win]
         - python    >=3
@@ -80,9 +76,7 @@ outputs:
         - {{ pin_subpackage("libllvm" + major_ver, exact=True) }}  # [not win]
     requirements:
       build:
-        - {{ compiler('cxx') }}            # [linux]
-        - vs2017_{{ target_platform }}    # [win]
-        - clang_bootstrap_osx-64           # [osx]
+        - {{ compiler('cxx') }}
         - cmake                    # [not win]
         - python    >=3            # [not win]
       host:
@@ -123,9 +117,7 @@ outputs:
       activate_in_script: True
     requirements:
       build:
-        - {{ compiler('cxx') }}            # [linux]
-        - vs2017_{{ target_platform }}     # [win]
-        - clang_bootstrap_osx-64           # [osx]
+        - {{ compiler('cxx') }}
         - cmake
         - ninja     # [win]
         - python    >=3


### PR DESCRIPTION
The 9.x branch for osx-arm64 was accidentally built for x86_64, hopefully this fixes it (but I'm still checking).