### PR TITLE
fix libcxx lower bound on osx

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -13,6 +13,8 @@ source:
     # - patches/expect-fastmath-entrypoints-in-add-TLI-mappings.ll.patch # adjusts test added in 10.0.0 for intel-D47188-svml-VF.patch effects
     # - patches/amd-roc-2.7.0.diff
     - patches/0001-pass-through-QEMU_LD_PREFIX-SDKROOT.patch
+    # fix for llvm/llvm-project#55137; can be dropped for v>14.0.2
+    - patches/0002-set-patch-version-correctly.patch
 
 build:
   number: 1

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -15,7 +15,7 @@ source:
     - patches/0001-pass-through-QEMU_LD_PREFIX-SDKROOT.patch
 
 build:
-  number: 0
+  number: 1
   merge_build_host: false
 
 requirements:
@@ -51,7 +51,7 @@ outputs:
       run:
         - {{ pin_subpackage("libllvm" + major_ver, exact=True) }}
         - {{ pin_subpackage("llvm-tools", exact=True) }}
-        - libcxx >={{ cxx_compiler_version }}.a0                        # [osx]
+        - libcxx >={{ cxx_compiler_version }}                           # [osx]
     test:
       commands:
         - $PREFIX/bin/llvm-config --libs                                # [not win]
@@ -77,10 +77,10 @@ outputs:
         - cmake                    # [not win]
         - python >=3               # [not win]
       host:
-        - libcxx >={{ cxx_compiler_version }}.a0  # [osx]
+        - libcxx >={{ cxx_compiler_version }}  # [osx]
         - zlib
       run:
-        - libcxx >={{ cxx_compiler_version }}.a0  # [osx]
+        - libcxx >={{ cxx_compiler_version }}  # [osx]
     test:
       commands:
         - test -f $PREFIX/lib/libLLVM-{{ major_ver }}${SHLIB_EXT}     # [not win]

--- a/recipe/patches/0001-pass-through-QEMU_LD_PREFIX-SDKROOT.patch
+++ b/recipe/patches/0001-pass-through-QEMU_LD_PREFIX-SDKROOT.patch
@@ -1,7 +1,7 @@
-From 9f73d2f8dd201349cdc0018fb66228b81e23c866 Mon Sep 17 00:00:00 2001
+From 5ef5b9b34b3648f2c81140f5f1a9a1cd459c26cd Mon Sep 17 00:00:00 2001
 From: Isuru Fernando <isuruf@gmail.com>
 Date: Tue, 4 Aug 2020 21:06:30 -0500
-Subject: [PATCH] pass through QEMU_LD_PREFIX & SDKROOT
+Subject: [PATCH 1/2] pass through QEMU_LD_PREFIX & SDKROOT
 
 ---
  llvm/utils/lit/lit/TestingConfig.py | 2 +-
@@ -21,5 +21,5 @@ index e80369377857..44f5794ed96b 100644
                       'UBSAN_OPTIONS', 'LSAN_OPTIONS', 'ADB', 'ANDROID_SERIAL',
                       'SSH_AUTH_SOCK', 'SANITIZER_IGNORE_CVE_2016_2143',
 -- 
-2.35.1.windows.2
+2.35.3.windows.1
 

--- a/recipe/patches/0002-set-patch-version-correctly.patch
+++ b/recipe/patches/0002-set-patch-version-correctly.patch
@@ -1,0 +1,25 @@
+From 27c9b4f648aaf4833d880239fbc055efc3836f58 Mon Sep 17 00:00:00 2001
+From: "H. Vetinari" <h.vetinari@gmx.com>
+Date: Thu, 28 Apr 2022 16:02:46 +1100
+Subject: [PATCH 2/2] set patch-version correctly
+
+---
+ llvm/CMakeLists.txt | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/llvm/CMakeLists.txt b/llvm/CMakeLists.txt
+index f8a25354978b..a9db267fbf4f 100644
+--- a/llvm/CMakeLists.txt
++++ b/llvm/CMakeLists.txt
+@@ -17,7 +17,7 @@ if(NOT DEFINED LLVM_VERSION_MINOR)
+   set(LLVM_VERSION_MINOR 0)
+ endif()
+ if(NOT DEFINED LLVM_VERSION_PATCH)
+-  set(LLVM_VERSION_PATCH 1)
++  set(LLVM_VERSION_PATCH 2)
+ endif()
+ if(NOT DEFINED LLVM_VERSION_SUFFIX)
+   set(LLVM_VERSION_SUFFIX)
+-- 
+2.35.3.windows.1
+


### PR DESCRIPTION
This fails e.g. in clang while trying to resolve `libcxx >=13.a0`. Either we're missing the `.0.0` for minor/patch, or the `.a0` should go.

Since I cannot see much context from https://github.com/conda-forge/llvmdev-feedstock/commit/633c21fe790dbdbe97579c8add367b758966d64c and the corresponding PR (except that it was a pre-release), I think the `.a0` can be deleted.

CC @isuruf