### PR TITLE
add entry-point for llvm-lit

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -17,7 +17,7 @@ source:
     - patches/0003-restore-macos-10.9-support.patch
 
 build:
-  number: 0
+  number: 1
   merge_build_host: false
 
 requirements:
@@ -155,7 +155,10 @@ outputs:
       activate_in_script: true
       skip: true  # [not linux64]
       entry_points:
+        # upstream LLVM is inconsistent; there's one way specified in lit's setup.py...
         - lit = lit.main:main
+        # ... and then the CMake files we install here (e.g. AddLLVM.cmake) look for another
+        - llvm-lit = lit.main:main
     requirements:
       host:
         - python >=3
@@ -167,6 +170,7 @@ outputs:
         - lit
       commands:
         - lit -h
+        - llvm-lit -h
 
 about:
   home: http://llvm.org/


### PR DESCRIPTION
By default, LLVM's  CMake files will [look](https://github.com/llvm/llvm-project/blame/llvmorg-16.0.2/llvm/cmake/modules/AddLLVM.cmake#L1851) for `llvm-lit`. Add this entry-point to make life easier for consuming feedstocks (i.e. without manually having to set `LLVM_EXTERNAL_LIT`).

The existing `lit` entrypoint here was set in https://github.com/conda-forge/llvmdev-feedstock/pull/67, not sure what rationale went into the naming at the time (matches pip import, though no discussion in the PR); in any case I think it would be fine to keep both.

PTAL @isuruf

CC @hmaarrfk 