### PR TITLE
[dev] Reinstate `libllvm-c{maj}` as part of `llvmdev`

### DIFF
--- a/.azure-pipelines/azure-pipelines-linux.yml
+++ b/.azure-pipelines/azure-pipelines-linux.yml
@@ -11,15 +11,15 @@ jobs:
       linux_64_:
         CONFIG: linux_64_
         UPLOAD_PACKAGES: 'True'
-        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-cos7-x86_64
+        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma9
       linux_aarch64_:
         CONFIG: linux_aarch64_
         UPLOAD_PACKAGES: 'True'
-        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-cos7-x86_64
+        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma9
       linux_ppc64le_:
         CONFIG: linux_ppc64le_
         UPLOAD_PACKAGES: 'True'
-        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-cos7-x86_64
+        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma9
   timeoutInMinutes: 360
   variables: {}
 

--- a/.azure-pipelines/azure-pipelines-win.yml
+++ b/.azure-pipelines/azure-pipelines-win.yml
@@ -54,6 +54,7 @@ jobs:
       displayName: Run Windows build
       env:
         MINIFORGE_HOME: $(MINIFORGE_HOME)
+        CONDA_BLD_PATH: $(CONDA_BLD_PATH)
         PYTHONUNBUFFERED: 1
         CONFIG: $(CONFIG)
         CI: azure

--- a/.azure-pipelines/azure-pipelines-win.yml
+++ b/.azure-pipelines/azure-pipelines-win.yml
@@ -19,24 +19,6 @@ jobs:
     UPLOAD_TEMP: D:\\tmp
 
   steps:
-
-    - task: PythonScript@0
-      displayName: 'Download Miniforge'
-      inputs:
-        scriptSource: inline
-        script: |
-          import urllib.request
-          url = 'https://github.com/conda-forge/miniforge/releases/latest/download/Miniforge3-Windows-x86_64.exe'
-          path = r"$(Build.ArtifactStagingDirectory)/Miniforge.exe"
-          urllib.request.urlretrieve(url, path)
-
-    - script: |
-        start /wait "" %BUILD_ARTIFACTSTAGINGDIRECTORY%\Miniforge.exe /InstallationType=JustMe /RegisterPython=0 /S /D=C:\Miniforge
-      displayName: Install Miniforge
-
-    - powershell: Write-Host "##vso[task.prependpath]C:\Miniforge\Scripts"
-      displayName: Add conda to PATH
-
     - powershell: |
         Set-Location "C:\Program Files (x86)\Microsoft Visual Studio\Installer\"
         $InstallPath = "C:\Program Files\Microsoft Visual Studio\2022\Enterprise"

--- a/.ci_support/linux_64_.yaml
+++ b/.ci_support/linux_64_.yaml
@@ -13,7 +13,7 @@ cxx_compiler:
 cxx_compiler_version:
 - '13'
 docker_image:
-- quay.io/condaforge/linux-anvil-cos7-x86_64
+- quay.io/condaforge/linux-anvil-x86_64:alma9
 libxml2:
 - '2'
 target_platform:

--- a/.ci_support/linux_aarch64_.yaml
+++ b/.ci_support/linux_aarch64_.yaml
@@ -1,11 +1,7 @@
-BUILD:
-- aarch64-conda_cos7-linux-gnu
 c_stdlib:
 - sysroot
 c_stdlib_version:
 - '2.17'
-cdt_arch:
-- aarch64
 cdt_name:
 - conda
 channel_sources:

--- a/.ci_support/linux_aarch64_.yaml
+++ b/.ci_support/linux_aarch64_.yaml
@@ -17,7 +17,7 @@ cxx_compiler:
 cxx_compiler_version:
 - '13'
 docker_image:
-- quay.io/condaforge/linux-anvil-cos7-x86_64
+- quay.io/condaforge/linux-anvil-x86_64:alma9
 libxml2:
 - '2'
 target_platform:

--- a/.ci_support/linux_ppc64le_.yaml
+++ b/.ci_support/linux_ppc64le_.yaml
@@ -13,7 +13,7 @@ cxx_compiler:
 cxx_compiler_version:
 - '13'
 docker_image:
-- quay.io/condaforge/linux-anvil-cos7-x86_64
+- quay.io/condaforge/linux-anvil-x86_64:alma9
 libxml2:
 - '2'
 target_platform:

--- a/.scripts/run_osx_build.sh
+++ b/.scripts/run_osx_build.sh
@@ -6,8 +6,9 @@ source .scripts/logging_utils.sh
 
 set -xe
 
-MINIFORGE_HOME=${MINIFORGE_HOME:-${HOME}/miniforge3}
-MINIFORGE_HOME=${MINIFORGE_HOME%/} # remove trailing slash
+MINIFORGE_HOME="${MINIFORGE_HOME:-${HOME}/miniforge3}"
+MINIFORGE_HOME="${MINIFORGE_HOME%/}" # remove trailing slash
+export CONDA_BLD_PATH="${CONDA_BLD_PATH:-${MINIFORGE_HOME}/conda-bld}"
 
 ( startgroup "Provisioning base env with micromamba" ) 2> /dev/null
 MICROMAMBA_VERSION="1.5.10-0"

--- a/.scripts/run_win_build.bat
+++ b/.scripts/run_win_build.bat
@@ -36,6 +36,7 @@ if !errorlevel! neq 0 exit /b !errorlevel!
 echo Removing %MAMBA_ROOT_PREFIX%
 del /S /Q "%MAMBA_ROOT_PREFIX%" >nul
 del /S /Q "%MICROMAMBA_TMPDIR%" >nul
+call :end_group
 
 call :start_group "Configuring conda"
 

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Current build status
     <td>
       <details>
         <summary>
-          <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=593&branchName=main">
+          <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=None&branchName=main">
             <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/llvmdev-feedstock?branchName=main">
           </a>
         </summary>
@@ -31,42 +31,42 @@ Current build status
           <tbody><tr>
               <td>linux_64</td>
               <td>
-                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=593&branchName=main">
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=None&branchName=main">
                   <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/llvmdev-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_64_" alt="variant">
                 </a>
               </td>
             </tr><tr>
               <td>linux_aarch64</td>
               <td>
-                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=593&branchName=main">
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=None&branchName=main">
                   <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/llvmdev-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_aarch64_" alt="variant">
                 </a>
               </td>
             </tr><tr>
               <td>linux_ppc64le</td>
               <td>
-                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=593&branchName=main">
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=None&branchName=main">
                   <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/llvmdev-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_ppc64le_" alt="variant">
                 </a>
               </td>
             </tr><tr>
               <td>osx_64</td>
               <td>
-                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=593&branchName=main">
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=None&branchName=main">
                   <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/llvmdev-feedstock?branchName=main&jobName=osx&configuration=osx%20osx_64_" alt="variant">
                 </a>
               </td>
             </tr><tr>
               <td>osx_arm64</td>
               <td>
-                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=593&branchName=main">
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=None&branchName=main">
                   <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/llvmdev-feedstock?branchName=main&jobName=osx&configuration=osx%20osx_arm64_" alt="variant">
                 </a>
               </td>
             </tr><tr>
               <td>win_64</td>
               <td>
-                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=593&branchName=main">
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=None&branchName=main">
                   <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/llvmdev-feedstock?branchName=main&jobName=win&configuration=win%20win_64_" alt="variant">
                 </a>
               </td>

--- a/build-locally.py
+++ b/build-locally.py
@@ -26,6 +26,13 @@ def setup_environment(ns):
             os.path.dirname(__file__), "miniforge3"
         )
 
+    # The default cache location might not be writable using docker on macOS.
+    if ns.config.startswith("linux") and platform.system() == "Darwin":
+        os.environ["CONDA_FORGE_DOCKER_RUN_ARGS"] = (
+            os.environ.get("CONDA_FORGE_DOCKER_RUN_ARGS", "")
+            + " -e RATTLER_CACHE_DIR=/tmp/rattler_cache"
+        )
+
 
 def run_docker_build(ns):
     script = ".scripts/run_docker_build.sh"

--- a/conda-forge.yml
+++ b/conda-forge.yml
@@ -1,5 +1,6 @@
 azure:
   settings_win:
+    install_atl: true
     variables:
       CONDA_BLD_PATH: C:\\bld\\
       MINIFORGE_HOME: C:\\Miniforge

--- a/recipe/install_llvm.sh
+++ b/recipe/install_llvm.sh
@@ -16,7 +16,7 @@ if [[ "${PKG_VERSION}" == *rc* ]]; then
     # (e.g. 19.1.0.rc1), so take the last part after splitting on "."
     MAJOR_EXT="${MAJOR_EXT}-${VER_ARR[3]}"
     SOVER_EXT="${SOVER_EXT}-${VER_ARR[3]}"
-elif [[ "${PKG_VERSION}" == *dev0 ]]; then
+elif [[ "${PKG_VERSION}" == *dev* ]]; then
     # otherwise with git suffix
     MAJOR_EXT="${MAJOR_EXT}git"
     SOVER_EXT="${SOVER_EXT}git"

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -13,8 +13,8 @@ package:
 
 source:
   # url: https://github.com/llvm/llvm-project/archive/refs/tags/llvmorg-{{ version.replace(".rc", "-rc") }}.tar.gz
-  url: https://github.com/llvm/llvm-project/archive/74449ab86b8bc8d7388ede0cc7fc3a679da0c567.tar.gz
-  sha256: 429b861248900cdd340963e10f9f134bb738b789f50e933d10724680312ec530
+  url: https://github.com/llvm/llvm-project/archive/0cda970ecc8a885acf7298a61370a1368b0ea39b.tar.gz
+  sha256: a9749646c9889a850b4bdac253d5db148e043e6a631c6a4556a2ade5a42a4cd0
   patches:
     # - patches/intel-D47188-svml-VF.patch    # Fixes vectorizer and extends SVML support
     # - patches/expect-fastmath-entrypoints-in-add-TLI-mappings.ll.patch # adjusts test added in 10.0.0 for intel-D47188-svml-VF.patch effects

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "20.0.0.dev0" %}
+{% set version = "20.0.0.dev1" %}
 {% set major_ver = version.split(".")[0] %}
 {% set tail_ver = version.split(".")[-1] %}
 {% set maj_min = major_ver ~ "." ~ version.split(".")[1] %}
@@ -13,8 +13,8 @@ package:
 
 source:
   # url: https://github.com/llvm/llvm-project/archive/refs/tags/llvmorg-{{ version.replace(".rc", "-rc") }}.tar.gz
-  url: https://github.com/llvm/llvm-project/archive/87bfa58a5a4b85416d2486797d0f21fc67da5cf3.tar.gz
-  sha256: 6453827c61593a987f51a5eaa265f4ccfc60901821c9bbb1c6fd1ac17681f0e3
+  url: https://github.com/llvm/llvm-project/archive/74449ab86b8bc8d7388ede0cc7fc3a679da0c567.tar.gz
+  sha256: 429b861248900cdd340963e10f9f134bb738b789f50e933d10724680312ec530
   patches:
     # - patches/intel-D47188-svml-VF.patch    # Fixes vectorizer and extends SVML support
     # - patches/expect-fastmath-entrypoints-in-add-TLI-mappings.ll.patch # adjusts test added in 10.0.0 for intel-D47188-svml-VF.patch effects
@@ -24,7 +24,7 @@ source:
     - patches/0002-llvm-LLVM_ENABLE_RUNTIMES-flang-rt.patch
 
 build:
-  number: 1
+  number: 0
   merge_build_host: false
 
 requirements:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,10 +1,11 @@
 {% set version = "20.0.0.dev0" %}
 {% set major_ver = version.split(".")[0] %}
+{% set tail_ver = version.split(".")[-1] %}
 {% set maj_min = major_ver ~ "." ~ version.split(".")[1] %}
 
 # as of LLVM 19, we expect an "-rcX" suffix for the release candidates
-{% set extra = "-" ~ version.split(".")[-1] if version.split(".")[-1] not in "0123456789" else "" %}
-{% set extra = "git" if version.split(".")[-1] == "dev0" else extra %}
+{% set extra = "-" ~ tail_ver if tail_ver not in "0123456789" else "" %}
+{% set extra = "git" if tail_ver|trim("0123456789") == "dev" else extra %}
 
 package:
   name: llvm-package
@@ -23,7 +24,7 @@ source:
     - patches/0002-llvm-LLVM_ENABLE_RUNTIMES-flang-rt.patch
 
 build:
-  number: 0
+  number: 1
   merge_build_host: false
 
 requirements:
@@ -61,14 +62,13 @@ outputs:
       host:
         - libcxx {{ cxx_compiler_version }}  # [osx]
         - {{ pin_subpackage("libllvm" ~ major_ver, exact=True) }}
-        # to avoid picking up LLVM-C.{dll,lib} as part of llvmdev
         - {{ pin_subpackage("libllvm-c" ~ major_ver, exact=True) }}     # [win]
         - {{ pin_subpackage("llvm-tools", exact=True) }}
         - zlib
         - zstd
       run:
-        # we're deliberately excluding "libllvm-c<maj>" on windows
         - {{ pin_subpackage("libllvm" ~ major_ver, exact=True) }}
+        - {{ pin_subpackage("libllvm-c" ~ major_ver, exact=True) }}     # [win]
         - {{ pin_subpackage("llvm-tools", exact=True) }}
         # we need to do this manually because clang_bootstrap has no run-export
         - libcxx >={{ cxx_compiler_version }}                           # [osx]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -22,6 +22,8 @@ source:
     - patches/0001-pass-through-QEMU_LD_PREFIX-SDKROOT.patch
     # backport llvm-bits of https://github.com/llvm/llvm-project/pull/110217
     - patches/0002-llvm-LLVM_ENABLE_RUNTIMES-flang-rt.patch
+    # backport https://github.com/llvm/llvm-project/pull/117949
+    - patches/0003-ExecutionEngine-reinstate-necessary-include.patch
 
 build:
   number: 0

--- a/recipe/patches/0001-pass-through-QEMU_LD_PREFIX-SDKROOT.patch
+++ b/recipe/patches/0001-pass-through-QEMU_LD_PREFIX-SDKROOT.patch
@@ -1,7 +1,7 @@
-From df8ca27b4fd2e5978a027f43a1e8f0724d68c504 Mon Sep 17 00:00:00 2001
+From 00088f14de929791e9f4a72589b90e4108324d42 Mon Sep 17 00:00:00 2001
 From: Isuru Fernando <isuruf@gmail.com>
 Date: Tue, 4 Aug 2020 21:06:30 -0500
-Subject: [PATCH 1/2] pass through QEMU_LD_PREFIX & SDKROOT
+Subject: [PATCH 1/3] pass through QEMU_LD_PREFIX & SDKROOT
 
 ---
  llvm/utils/lit/lit/TestingConfig.py | 2 ++

--- a/recipe/patches/0001-pass-through-QEMU_LD_PREFIX-SDKROOT.patch
+++ b/recipe/patches/0001-pass-through-QEMU_LD_PREFIX-SDKROOT.patch
@@ -1,4 +1,4 @@
-From 00088f14de929791e9f4a72589b90e4108324d42 Mon Sep 17 00:00:00 2001
+From 2059bf7c412609c04ba32fbc7ee07e7eeb3d480a Mon Sep 17 00:00:00 2001
 From: Isuru Fernando <isuruf@gmail.com>
 Date: Tue, 4 Aug 2020 21:06:30 -0500
 Subject: [PATCH 1/3] pass through QEMU_LD_PREFIX & SDKROOT

--- a/recipe/patches/0002-llvm-LLVM_ENABLE_RUNTIMES-flang-rt.patch
+++ b/recipe/patches/0002-llvm-LLVM_ENABLE_RUNTIMES-flang-rt.patch
@@ -1,4 +1,4 @@
-From 082e81a3cb43c04a49684ebd918726cc1dbfa05c Mon Sep 17 00:00:00 2001
+From 4f9f2ed0d9270f15496da245a83acff04b7b93f7 Mon Sep 17 00:00:00 2001
 From: Michael Kruse <llvm-project@meinersbur.de>
 Date: Fri, 27 Sep 2024 09:18:49 +0200
 Subject: [PATCH 2/3] [llvm] LLVM_ENABLE_RUNTIMES=flang-rt
@@ -9,15 +9,15 @@ mechanism.
  llvm/CMakeLists.txt                           |  8 +++++-
  .../modules/LLVMExternalProjectUtils.cmake    | 16 +++++++++++-
  llvm/projects/CMakeLists.txt                  |  4 ++-
- llvm/runtimes/CMakeLists.txt                  | 26 ++++++++++++++-----
- 4 files changed, 44 insertions(+), 10 deletions(-)
+ llvm/runtimes/CMakeLists.txt                  | 25 +++++++++++++------
+ 4 files changed, 43 insertions(+), 10 deletions(-)
 
 diff --git a/llvm/CMakeLists.txt b/llvm/CMakeLists.txt
-index cfcf1404d82b..7c5122bdb1ef 100644
+index f14065ab0379..9a1dc824658f 100644
 --- a/llvm/CMakeLists.txt
 +++ b/llvm/CMakeLists.txt
-@@ -150,12 +150,18 @@ if ("flang" IN_LIST LLVM_ENABLE_PROJECTS)
-   endif()
+@@ -157,12 +157,18 @@ if ("libc" IN_LIST LLVM_ENABLE_PROJECTS)
+     "https://libc.llvm.org/ for building the runtimes.")
  endif()
  
 +if ("flang-rt" IN_LIST LLVM_ENABLE_RUNTIMES)
@@ -128,18 +128,10 @@ index 08f2fa522420..f254cf10806d 100644
  
  add_llvm_external_project(dragonegg)
 diff --git a/llvm/runtimes/CMakeLists.txt b/llvm/runtimes/CMakeLists.txt
-index 57a56c6a6041..da1709267160 100644
+index 40fdb14e8133..c237c0be2afe 100644
 --- a/llvm/runtimes/CMakeLists.txt
 +++ b/llvm/runtimes/CMakeLists.txt
-@@ -96,6 +96,7 @@ function(builtin_default_target compiler_rt_path)
-                                       -DLLVM_ENABLE_PER_TARGET_RUNTIME_DIR=${LLVM_ENABLE_PER_TARGET_RUNTIME_DIR}
-                                       -DLLVM_CMAKE_DIR=${CMAKE_BINARY_DIR}
-                                       -DCMAKE_C_COMPILER_WORKS=ON
-+                                      -DCMAKE_Fortran_COMPILER_WORKS=ON
-                                       -DCMAKE_ASM_COMPILER_WORKS=ON
-                                       ${COMMON_CMAKE_ARGS}
-                                       ${BUILTINS_CMAKE_ARGS}
-@@ -230,7 +231,7 @@ foreach(entry ${runtimes})
+@@ -230,7 +230,7 @@ foreach(entry ${runtimes})
  endforeach()
  
  function(runtime_default_target)
@@ -148,7 +140,7 @@ index 57a56c6a6041..da1709267160 100644
  
    include(${LLVM_BINARY_DIR}/runtimes/Components.cmake OPTIONAL)
    set(SUB_CHECK_TARGETS ${SUB_CHECK_TARGETS} PARENT_SCOPE)
-@@ -270,13 +271,15 @@ function(runtime_default_target)
+@@ -270,13 +270,15 @@ function(runtime_default_target)
                                        -DLLVM_BUILD_TOOLS=${LLVM_BUILD_TOOLS}
                                        -DCMAKE_C_COMPILER_WORKS=ON
                                        -DCMAKE_CXX_COMPILER_WORKS=ON
@@ -165,7 +157,7 @@ index 57a56c6a6041..da1709267160 100644
                                                  ${ARG_PREFIXES}
                             EXTRA_TARGETS ${extra_targets}
                                           ${test_targets}
-@@ -286,7 +289,7 @@ function(runtime_default_target)
+@@ -286,7 +288,7 @@ function(runtime_default_target)
                             USE_TOOLCHAIN
                             TARGET_TRIPLE ${LLVM_TARGET_TRIPLE}
                             FOLDER "Runtimes"
@@ -174,7 +166,7 @@ index 57a56c6a6041..da1709267160 100644
  endfunction()
  
  # runtime_register_target(name)
-@@ -403,6 +406,7 @@ function(runtime_register_target name)
+@@ -403,6 +405,7 @@ function(runtime_register_target name)
                                        -DLLVM_ENABLE_PER_TARGET_RUNTIME_DIR=${LLVM_ENABLE_PER_TARGET_RUNTIME_DIR}
                                        -DCMAKE_C_COMPILER_WORKS=ON
                                        -DCMAKE_CXX_COMPILER_WORKS=ON
@@ -182,7 +174,7 @@ index 57a56c6a6041..da1709267160 100644
                                        -DCMAKE_ASM_COMPILER_WORKS=ON
                                        -DCOMPILER_RT_DEFAULT_TARGET_ONLY=ON
                                        -DLLVM_RUNTIMES_TARGET=${name}
-@@ -462,10 +466,13 @@ if(build_runtimes)
+@@ -462,10 +465,13 @@ if(build_runtimes)
    # together in a single CMake invocation.
    set(extra_deps "")
    set(extra_cmake_args "")
@@ -196,7 +188,7 @@ index 57a56c6a6041..da1709267160 100644
                  count
                  lld
                  lli
-@@ -566,19 +573,24 @@ if(build_runtimes)
+@@ -548,19 +554,24 @@ if(build_runtimes)
    if(LLVM_LIBC_FULL_BUILD)
      list(APPEND extra_cmake_args "-DLLVM_LIBC_FULL_BUILD=ON")
    endif()
@@ -223,7 +215,7 @@ index 57a56c6a6041..da1709267160 100644
        list(REMOVE_ITEM LLVM_RUNTIME_TARGETS "default")
      else()
        add_custom_target(runtimes)
-@@ -625,7 +637,7 @@ if(build_runtimes)
+@@ -607,7 +618,7 @@ if(build_runtimes)
        runtime_register_target(${name}
          DEPENDS ${builtins_dep_name} ${extra_deps}
          CMAKE_ARGS -DLLVM_DEFAULT_TARGET_TRIPLE=${name} ${extra_cmake_args}
@@ -232,7 +224,7 @@ index 57a56c6a6041..da1709267160 100644
      endforeach()
  
      foreach(multilib ${LLVM_RUNTIME_MULTILIBS})
-@@ -637,7 +649,7 @@ if(build_runtimes)
+@@ -619,7 +630,7 @@ if(build_runtimes)
                       -DLLVM_RUNTIMES_LIBDIR_SUBDIR=${multilib}
                       ${extra_cmake_args}
            BASE_NAME ${name}

--- a/recipe/patches/0002-llvm-LLVM_ENABLE_RUNTIMES-flang-rt.patch
+++ b/recipe/patches/0002-llvm-LLVM_ENABLE_RUNTIMES-flang-rt.patch
@@ -1,7 +1,7 @@
-From 6ad1d64cf35db9f989a9626d8d3d1cc4b64ac3bb Mon Sep 17 00:00:00 2001
+From 082e81a3cb43c04a49684ebd918726cc1dbfa05c Mon Sep 17 00:00:00 2001
 From: Michael Kruse <llvm-project@meinersbur.de>
 Date: Fri, 27 Sep 2024 09:18:49 +0200
-Subject: [PATCH 2/2] [llvm] LLVM_ENABLE_RUNTIMES=flang-rt
+Subject: [PATCH 2/3] [llvm] LLVM_ENABLE_RUNTIMES=flang-rt
 
 Extract Flang's runtime library to use the LLVM_ENABLE_RUNTIME
 mechanism.
@@ -13,7 +13,7 @@ mechanism.
  4 files changed, 44 insertions(+), 10 deletions(-)
 
 diff --git a/llvm/CMakeLists.txt b/llvm/CMakeLists.txt
-index cde4a999ea2e..bb0fd378b38e 100644
+index cfcf1404d82b..7c5122bdb1ef 100644
 --- a/llvm/CMakeLists.txt
 +++ b/llvm/CMakeLists.txt
 @@ -150,12 +150,18 @@ if ("flang" IN_LIST LLVM_ENABLE_PROJECTS)

--- a/recipe/patches/0003-ExecutionEngine-reinstate-necessary-include.patch
+++ b/recipe/patches/0003-ExecutionEngine-reinstate-necessary-include.patch
@@ -1,4 +1,4 @@
-From 622f287c053a6fa764d8142a40ca227ad20603ee Mon Sep 17 00:00:00 2001
+From 6672bc7778552032853ef84c3e071b5f8e9e0787 Mon Sep 17 00:00:00 2001
 From: "H. Vetinari" <h.vetinari@gmx.com>
 Date: Thu, 28 Nov 2024 12:30:26 +1100
 Subject: [PATCH 3/3] [ExecutionEngine] reinstate necessary include

--- a/recipe/patches/0003-ExecutionEngine-reinstate-necessary-include.patch
+++ b/recipe/patches/0003-ExecutionEngine-reinstate-necessary-include.patch
@@ -1,0 +1,21 @@
+From 622f287c053a6fa764d8142a40ca227ad20603ee Mon Sep 17 00:00:00 2001
+From: "H. Vetinari" <h.vetinari@gmx.com>
+Date: Thu, 28 Nov 2024 12:30:26 +1100
+Subject: [PATCH 3/3] [ExecutionEngine] reinstate necessary include
+
+---
+ llvm/lib/ExecutionEngine/Orc/TargetProcess/JITLoaderVTune.cpp | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/llvm/lib/ExecutionEngine/Orc/TargetProcess/JITLoaderVTune.cpp b/llvm/lib/ExecutionEngine/Orc/TargetProcess/JITLoaderVTune.cpp
+index fb7cf94fa065..57ac991ee37f 100644
+--- a/llvm/lib/ExecutionEngine/Orc/TargetProcess/JITLoaderVTune.cpp
++++ b/llvm/lib/ExecutionEngine/Orc/TargetProcess/JITLoaderVTune.cpp
+@@ -11,6 +11,7 @@
+ 
+ #include "llvm/ExecutionEngine/Orc/TargetProcess/JITLoaderVTune.h"
+ #include "llvm/ExecutionEngine/Orc/Shared/VTuneSharedStructs.h"
++#include <map>
+ 
+ #if LLVM_USE_INTEL_JITEVENTS
+ #include "IntelJITEventsWrapper.h"


### PR DESCRIPTION
Forward-port #301; update to https://github.com/llvm/llvm-project/commit/0cda970ecc8a885acf7298a61370a1368b0ea39b for next round of flang-rt builds.